### PR TITLE
Use ENV vars for ipfsDomain/ipfsApiPort when available

### DIFF
--- a/src/services/ipfs-service.js
+++ b/src/services/ipfs-service.js
@@ -10,8 +10,8 @@ class IpfsService {
 
     // TODO: Allow override of these by config file
     // this.ipfsDomain = 'gateway.originprotocol.com' // Production
-    this.ipfsDomain = '127.0.0.1' // Local IPFS daemon
-    this.ipfsApiPort = '5001'
+    this.ipfsDomain = process.env.IPFS_DOMAIN || '127.0.0.1' // Local IPFS daemon
+    this.ipfsApiPort = process.env.IPFS_API_PORT || '5001'
     this.ipfsGatewayPort = '8080'
 
     console.log("this.ipfsDomain:" + this.ipfsDomain)


### PR DESCRIPTION
Forgot to bring this change along in the last PR.