### PR TITLE
add ScrollToTop component for routing

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -6,6 +6,7 @@ import {
 import { Web3Provider } from 'react-web3'
 
 // Components
+import ScrollToTop from './scroll-to-top.js';
 import Listings from './listings-grid.js'
 import ListingDetail from './listing-detail.js'
 import ListingCreate from './listing-create.js'
@@ -83,16 +84,18 @@ const Web3UnavailableScreen = () => {
 // Top level component
 const App = () => (
   <Router>
-    <Web3Provider
-      web3UnavailableScreen={() => <Web3UnavailableScreen />}
-      accountUnavailableScreen={() => <AccountUnavailableScreen />}
-    >
-      <div>
-        <Route exact path="/" component={HomePage}/>
-        <Route path="/listing/:listingId" component={ListingDetailPage}/>
-        <Route path="/create" component={CreateListingPage}/>
-      </div>
-    </Web3Provider>
+    <ScrollToTop>
+      <Web3Provider
+        web3UnavailableScreen={() => <Web3UnavailableScreen />}
+        accountUnavailableScreen={() => <AccountUnavailableScreen />}
+      >
+        <div>
+          <Route exact path="/" component={HomePage}/>
+          <Route path="/listing/:listingId" component={ListingDetailPage}/>
+          <Route path="/create" component={CreateListingPage}/>
+        </div>
+      </Web3Provider>
+    </ScrollToTop>
   </Router>
 )
 

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -122,7 +122,6 @@ class ListingCreate extends Component {
   }
 
   render() {
-    window.scrollTo(0, 0)
     return (
       <div className="container listing-form">
         { this.state.step === this.STEP.PICK_SCHEMA &&

--- a/src/components/scroll-to-top.js
+++ b/src/components/scroll-to-top.js
@@ -1,0 +1,16 @@
+import { Component } from 'react';
+import { withRouter } from 'react-router';
+
+class ScrollToTop extends Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location !== prevProps.location) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+export default withRouter(ScrollToTop);

--- a/src/components/scroll-to-top.js
+++ b/src/components/scroll-to-top.js
@@ -1,16 +1,16 @@
-import { Component } from 'react';
-import { withRouter } from 'react-router';
+import { Component } from 'react'
+import { withRouter } from 'react-router'
 
 class ScrollToTop extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.location !== prevProps.location) {
-      window.scrollTo(0, 0);
+      window.scrollTo(0, 0)
     }
   }
 
   render() {
-    return this.props.children;
+    return this.props.children
   }
 }
 
-export default withRouter(ScrollToTop);
+export default withRouter(ScrollToTop)


### PR DESCRIPTION
Fix for #72 Handle scrolling correctly will always scroll to top when there is a routing page change.

Does not fix scroll to top on the grid, as that requires the routing changes in #64 Add paging to URLs / Router that I am looking into separately.