### PR TITLE
issue/81 use a sticky footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ candy maple cake sugar pudding cream honey rich smooth crumble sweet treat
 
 9. Click where it says "Ethereum Main Network", select "Custom RPC" and enter `http://localhost:9545/`. This takes us off of the real ETH blockchain and onto our local blockchain. Click the back arrow to return to your account.
 
- **Be careful not to mix up your test wallet with you real one on the Main Network.**
+ **Be careful not to mix up your test wallet with your real one on the Main Network.**
 
 10. You should see your first test account now has 100 ETH. (Address of `0x627306090abaB3A6e1400e9345bC60c78a8BEf57`) Additional generated accounts will also have this amount.
 

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -6,7 +6,7 @@ import {
 import { Web3Provider } from 'react-web3'
 
 // Components
-import ScrollToTop from './scroll-to-top.js';
+import ScrollToTop from './scroll-to-top.js'
 import Listings from './listings-grid.js'
 import ListingDetail from './listing-detail.js'
 import ListingCreate from './listing-create.js'
@@ -21,80 +21,76 @@ import '../css/poppins.css'
 import '../css/app.css'
 
 
-const HomePage = () => {
-  return (
-    <main>
-      <NavBar />
-      <div className="container">
-        <Listings />
-      </div>
-      <Footer />
-    </main>
-  )
-}
-
-const ListingDetailPage = (props) => (
-  <div>
-    <NavBar />
-    <ListingDetail listingId={props.match.params.listingId} />
-    <Footer />
-  </div>
+const HomePage = (props) => (
+  <Layout {...props}>
+    <div className="container">
+      <Listings />
+    </div>
+  </Layout>
 )
 
-const CreateListingPage = () => (
-  <div>
-    <NavBar hideCreateButton="true" />
+const ListingDetailPage = (props) => (
+  <Layout {...props}>
+    <ListingDetail listingId={props.match.params.listingId} />
+  </Layout>
+)
+
+const CreateListingPage = (props) => (
+  <Layout {...props} hideCreateButton={true}>
     <div className="container">
       <ListingCreate />
     </div>
+  </Layout>
+)
+
+const AccountUnavailableScreen = (props) => (
+  <Layout {...props}>
+    <Overlay imageUrl="/images/flat_cross_icon.svg">
+      You are not signed in to MetaMask.<br />
+    </Overlay>
+    <div className="container empty-page" />
+  </Layout>
+)
+
+const Web3UnavailableScreen = (props) => (
+  <Layout {...props}>
+    <Overlay imageUrl="/images/flat_cross_icon.svg">
+      MetaMask extension not installed.<br />
+      <a target="_blank" href="https://metamask.io/">Get MetaMask</a><br />
+      <a target="_blank" href="https://medium.com/originprotocol/origin-demo-dapp-is-now-live-on-testnet-835ae201c58">
+        Full Instructions for Demo
+      </a>
+    </Overlay>
+    <div className="container empty-page" />
+  </Layout>
+)
+
+const Layout = ({ children, hideCreateButton }) => (
+  <div>
+    <main>
+      <NavBar hideCreateButton={hideCreateButton} />
+      {children}
+    </main>
     <Footer />
   </div>
 )
-
-const AccountUnavailableScreen = () => {
-  return (
-    <main>
-      <NavBar />
-      <Overlay imageUrl="/images/flat_cross_icon.svg">
-        You are not signed in to MetaMask.<br />
-      </Overlay>
-      <div className="container empty-page" />
-      <Footer />
-    </main>
-  )
-}
-
-const Web3UnavailableScreen = () => {
-  return (
-    <main>
-      <NavBar />
-      <Overlay imageUrl="/images/flat_cross_icon.svg">
-        MetaMask extension not installed.<br />
-        <a target="_blank" href="https://metamask.io/">Get MetaMask</a><br />
-        <a target="_blank" href="https://medium.com/originprotocol/origin-demo-dapp-is-now-live-on-testnet-835ae201c58">
-          Full Instructions for Demo
-        </a>
-      </Overlay>
-      <div className="container empty-page" />
-      <Footer />
-    </main>
-  )
-}
 
 // Top level component
 const App = () => (
   <Router>
     <ScrollToTop>
-      <Web3Provider
-        web3UnavailableScreen={() => <Web3UnavailableScreen />}
-        accountUnavailableScreen={() => <AccountUnavailableScreen />}
-      >
-        <div>
-          <Route exact path="/" component={HomePage}/>
-          <Route path="/listing/:listingId" component={ListingDetailPage}/>
-          <Route path="/create" component={CreateListingPage}/>
-        </div>
-      </Web3Provider>
+      <div>
+        <Web3Provider
+          web3UnavailableScreen={() => <Web3UnavailableScreen />}
+          accountUnavailableScreen={() => <AccountUnavailableScreen />}
+        >
+          <div>
+            <Route exact path="/" component={HomePage} />
+            <Route path="/listing/:listingId" component={ListingDetailPage} />
+            <Route path="/create" component={CreateListingPage} />
+          </div>
+        </Web3Provider>
+      </div>
     </ScrollToTop>
   </Router>
 )

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -67,10 +67,13 @@ const Footer = (props) => {
                 </div>
                 <ul className="footer-links">
                   <li>
+                    <a href="http://www.originprotocol.com/team">Team</a>
+                  </li>
+                  <li>
                     <a href="http://www.originprotocol.com/presale">Presale</a>
                   </li>
                   <li>
-                    <a href="http://www.originprotocol.com/team">Team</a>
+                    <a href="http://www.originprotocol.com/partners">Partners</a>
                   </li>
                   <li>
                     <a href="https://angel.co/originprotocol/jobs">Jobs (We&rsquo;re hiring!)</a>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -12,6 +12,23 @@ body {
   font-family: 'Lato', 'Helvetica Neue', 'Arial', sans-serif;
 }
 
+/* necessary for every sticky footer ancestor */
+#root, #root > div, #root > div > div {
+  height: 100%;
+}
+
+/* sticky footer parent */
+#root > div > div > div {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* sticky footer sibling */
+main {
+  flex: 1 0 auto;
+}
+
 /* Common */
 
 h1, h2, h3 {


### PR DESCRIPTION
This resolves #81. It also made sense to add a shared layout to the components in an effort to preserve the footer implementation. This involved adding an extra wrapper div or two, but that is common in React projects. The commit also adds the new partners link to the footer.