### PR TITLE
Issue/46 replace alerts with styled message boxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -120,6 +110,9 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
+    },
+    "alertify": {
+      "version": "github:micahalcorn/alertify.js#fe25d03893b0a10697127df2b1d90718be47089e"
     },
     "align-text": {
       "version": "0.1.4",
@@ -1672,9 +1665,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
+        "JSONStream": "1.3.2",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -1702,7 +1695,6 @@
       "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -1724,6 +1716,7 @@
         "https-browserify": "0.0.1",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
+        "JSONStream": "1.3.2",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -5450,6 +5443,13 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5457,13 +5457,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6272,10 +6265,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
+        "JSONStream": "1.3.2",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -7298,6 +7291,16 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "jsprim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
@@ -8290,7 +8293,6 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -8298,6 +8300,7 @@
         "detective": "4.7.1",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
+        "JSONStream": "1.3.2",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.4.0",
@@ -11416,6 +11419,14 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -11435,14 +11446,6 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
         "function-bind": "1.1.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "whatwg-fetch": "1.0.0"
   },
   "dependencies": {
+    "alertify": "github:micahalcorn/alertify.js#webpack_friendly",
     "bs58": "^4.0.1",
     "dotenv": "^2.0.0",
     "ethereumjs-testrpc": "^4.1.3",

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -7,6 +7,8 @@ import ListingDetail from './listing-detail'
 import Form from 'react-jsonschema-form'
 import Overlay from './overlay'
 
+const alertify = require('../../node_modules/alertify/src/alertify.js')
+
 class ListingCreate extends Component {
 
   constructor(props) {
@@ -88,7 +90,7 @@ class ListingCreate extends Component {
       return bytes
     }
     if (roughSizeOfObject(formListing.formData) > this.MAX_UPLOAD_BYTES) {
-      alert("Your listing is too large. Consider using fewer or smaller photos.")
+      alertify.log("Your listing is too large. Consider using fewer or smaller photos.")
     } else {
       this.setState({
         formListing: formListing,
@@ -110,13 +112,13 @@ class ListingCreate extends Component {
       })
       .catch((error) => {
         console.error(error)
-        alert(error)
+        alertify.log(error.message)
         // TODO: Reset form? Do something.
       })
     })
     .catch((error) => {
       console.error(error)
-      alert(error)
+      alertify.log(error.message)
       // TODO: Reset form? Do something.
     })
   }

--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -4,6 +4,8 @@ import ipfsService from '../services/ipfs-service'
 
 import Overlay from './overlay'
 
+const alertify = require('../../node_modules/alertify/src/alertify.js')
+
 class ListingsDetail extends Component {
 
   constructor(props) {
@@ -74,7 +76,7 @@ class ListingsDetail extends Component {
     })
     .catch((error) => {
       console.log(error)
-      alert(error)
+      alertify.log(error.message)
       this.setState({step: this.STEP.VIEW})
     })
   }

--- a/src/components/listings-grid.js
+++ b/src/components/listings-grid.js
@@ -4,6 +4,8 @@ import Pagination from 'react-js-pagination'
 
 import ListingCard from './listing-card'
 
+const alertify = require('../../node_modules/alertify/src/alertify.js')
+
 class ListingsGrid extends Component {
 
   constructor(props, context) {
@@ -49,7 +51,7 @@ class ListingsGrid extends Component {
     })
     .catch((error) => {
       console.log(error)
-      alert(error.message)
+      alertify.log(error.message)
     })
   }
 

--- a/src/css/alertify.css
+++ b/src/css/alertify.css
@@ -1,0 +1,16 @@
+@import '../../node_modules/alertify/themes/alertify.core.css';
+
+.alertify-log {
+  padding: 20px;
+  border-radius: 4px;
+  color: #212529;
+  font-size:18px;
+  font-weight: 400;
+  text-align: center;
+  box-shadow: 1px 1px 20px 0 rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='25' height='30'><line x1='5' y1='10' x2='15' y2='20' stroke='%23bbb' stroke-width='2'/><line x1='15' y1='10' x2='5' y2='20' stroke='%23bbb' stroke-width='2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right top;
+  background-color: #ebf0f3;
+}

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1,3 +1,5 @@
+@import 'alertify.css';
+
 html {
   height: 100%;
   font-size: 16px;


### PR DESCRIPTION
This addresses #46 by implementing the [unmaintained version of Alertify](https://github.com/fabien-d/alertify.js) with the same [branch](https://github.com/fabien-d/alertify.js/tree/0.3) and styles as the [company-website](https://github.com/OriginProtocol/company-website/commit/1c10ad36025dcb2c4a0705945dffeb5da8879092).

**Note**
There may be a more appropriate way to import the module with some kind of webpack configuration. This PR currently uses [a fork](https://github.com/micahalcorn/alertify.js/tree/webpack_friendly), which provides the [necessary global context](https://github.com/micahalcorn/alertify.js/commit/fe25d03893b0a10697127df2b1d90718be47089e) for the library to access the `document`.