### PR TITLE
json updates to 6 files in public/schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,10 +106,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true,
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
+      "integrity": "sha1-hlWl2G0IJJhcxHGh2RP7Zymg7Eg=",
       "requires": {
         "co": "4.6.0",
         "json-stable-stringify": "1.0.1"
@@ -2128,7 +2127,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -4780,13 +4779,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "optional": true,
       "requires": {
         "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -4920,7 +4919,6 @@
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -4959,6 +4957,11 @@
         },
         "delegates": {
           "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
           "bundled": true,
           "optional": true
         },
@@ -5086,7 +5089,6 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -5235,10 +5237,12 @@
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.36",
+          "version": "0.6.39",
           "bundled": true,
           "optional": true,
           "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.0",
@@ -5422,7 +5426,6 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -5849,6 +5852,18 @@
       "requires": {
         "ajv": "4.11.8",
         "har-schema": "1.0.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
       }
     },
     "has": {
@@ -7249,7 +7264,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -7283,8 +7297,7 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -11584,6 +11597,16 @@
         "string-width": "2.1.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "whatwg-fetch": "1.0.0"
   },
   "dependencies": {
+    "ajv": "^4.11.7",
     "bs58": "^4.0.1",
     "dotenv": "^2.0.0",
     "ethereumjs-testrpc": "^4.1.3",

--- a/public/schemas/announcements.json
+++ b/public/schemas/announcements.json
@@ -1,5 +1,5 @@
 {
-  "$schema":"http://json-schema.org/draft-04/schema#",
+  "$schema":"http://json-schema.org/draft-06/schema#",
   "description":"Distributed Nextdoor",
   "type": "object",
   "required": ["name","category","description"],
@@ -7,8 +7,8 @@
     "name": {
       "type": "string",
       "title": "Title",
-      "minLength": "3",
-      "maxLength": "100"
+      "minLength": 3,
+      "maxLength": 100
     },
     "category": {
       "type": "string",
@@ -34,8 +34,8 @@
     "description": {
       "type": "string",
       "title": "Description",
-      "minLength": "10",
-      "maxLength": "1024"
+      "minLength": 10,
+      "maxLength": 1024
     },
     "pictures": {
       "type": "array",

--- a/public/schemas/for-sale.json
+++ b/public/schemas/for-sale.json
@@ -1,5 +1,5 @@
 {
-  "$schema":"http://json-schema.org/draft-04/schema#",
+  "$schema":"http://json-schema.org/draft-06/schema#",
   "description":"Distributed Craigslist/Ebay/Amazon",
   "type": "object",
   "required": ["name","category","description","price"],
@@ -7,8 +7,8 @@
     "name": {
       "type": "string",
       "title": "Title",
-      "minLength": "3",
-      "maxLength": "100"
+      "minLength": 3,
+      "maxLength": 100
     },
     "category": {
       "type": "string",
@@ -64,8 +64,8 @@
     "description": {
       "type": "string",
       "title": "Description",
-      "minLength": "10",
-      "maxLength": "1024"
+      "minLength": 10,
+      "maxLength": 1024
     },
     "location": {
       "type": "string",

--- a/public/schemas/housing.json
+++ b/public/schemas/housing.json
@@ -1,5 +1,5 @@
 {
-  "$schema":"http://json-schema.org/draft-04/schema#",
+  "$schema":"http://json-schema.org/draft-06/schema#",
   "description": "Distributed Airbnb",
   "type": "object",
   "required": ["name","category","description","price"],
@@ -7,8 +7,8 @@
     "name": {
       "type": "string",
       "title": "Title",
-      "minLength": "3",
-      "maxLength": "100"
+      "minLength": 3,
+      "maxLength": 100
     },
     "category": {
       "type": "string",
@@ -32,8 +32,8 @@
     "description": {
       "type": "string",
       "title": "Description",
-      "minLength": "10",
-      "maxLength": "1024"
+      "minLength": 10,
+      "maxLength": 1024
     },
     "location": {
       "type": "string",

--- a/public/schemas/services.json
+++ b/public/schemas/services.json
@@ -1,5 +1,5 @@
 {
-  "$schema":"http://json-schema.org/draft-04/schema#",
+  "$schema":"http://json-schema.org/draft-06/schema#",
   "description": "Distributed Elance/99 Designs/Postmates/Fiver/Handy/Thumbtack",
   "type": "object",
   "required": ["name","category","description","price"],
@@ -7,8 +7,8 @@
     "name": {
       "type": "string",
       "title": "Title",
-      "minLength": "3",
-      "maxLength": "100"
+      "minLength": 3,
+      "maxLength": 100
     },
     "category": {
       "type": "string",
@@ -37,8 +37,8 @@
     "description": {
       "type": "string",
       "title": "Description",
-      "minLength": "10",
-      "maxLength": "1024"
+      "minLength": 10,
+      "maxLength": 1024
     },
     "location": {
       "type": "string",

--- a/public/schemas/tickets.json
+++ b/public/schemas/tickets.json
@@ -1,5 +1,5 @@
 {
-  "$schema":"http://json-schema.org/draft-04/schema#",
+  "$schema":"http://json-schema.org/draft-06/schema#",
   "description": "Distributed Ticketmaster/Eventbrite",
   "type": "object",
   "required": ["name","category","description","price"],
@@ -7,8 +7,8 @@
     "name": {
       "type": "string",
       "title": "Title",
-      "minLength": "3",
-      "maxLength": "100"
+      "minLength": 3,
+      "maxLength": 100
     },
     "category": {
       "type": "string",
@@ -38,8 +38,8 @@
     "description": {
       "type": "string",
       "title": "Description",
-      "minLength": "10",
-      "maxLength": "1024"
+      "minLength": 10,
+      "maxLength": 1024
     },
     "price": {
       "type": "number",

--- a/public/schemas/transportation.json
+++ b/public/schemas/transportation.json
@@ -1,5 +1,5 @@
 {
-  "$schema":"http://json-schema.org/draft-04/schema#",
+  "$schema":"http://json-schema.org/draft-06/schema#",
   "description": "Distributed Getaround",
   "type": "object",
   "required": ["name","category","description","price"],
@@ -7,8 +7,8 @@
     "name": {
       "type": "string",
       "title": "Title",
-      "minLength": "3",
-      "maxLength": "100"
+      "minLength": 3,
+      "maxLength": 100
     },
     "category": {
       "type": "string",
@@ -26,8 +26,8 @@
     "description": {
       "type": "string",
       "title": "Description",
-      "minLength": "10",
-      "maxLength": "1024"
+      "minLength": 10,
+      "maxLength": 1024
     },
     "location": {
       "type": "string",


### PR DESCRIPTION
1) Updated $schema":"http://json-schema.org/draft-04/schema#" to 
"$schema":"http://json-schema.org/draft-06/schema#"

2) Changed types on all min/max field values from string to integer.

Original draft-04 was throwing an error in my linux Firefox (v58.0.2) dev console:
"Error: no schema with key or ref".

I changed the source json $schema values to use draft-06, and then saw a more useful error message. Can't recall the exact error syntax, but it referred to all of the min/max fields being invalid string types, which I then fixed to be integers. That solved the issue.

I suspect the original draft-04 schemas were working in other os/browser environments, due to a less stringent JVM running in those browsers. Perhaps the linux Firefox JVM was less forgiving?

Neil