### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ npm run start
 
 ## Get involved
 
-We'd love to have you join us on this project.  We're still in the super early stages, but join our [slack channel](http://slack.originprotocol.com) or [email us](mailto:founders@originprotocol.com) to get started.
+We'd love to have you join us on this project.  We're still in the super early stages, but join our [Discord channel](https://discord.gg/jyxpUSe) or [email us](mailto:founders@originprotocol.com) to get started.


### PR DESCRIPTION
Changing Slack link to Discord link in "Get involved" section