### PR TITLE
Fix NaN price display in announcement creation

### DIFF
--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -81,6 +81,7 @@ class ListingsDetail extends Component {
 
 
   render() {
+    const price = typeof this.state.price === 'string' ? 0 : this.state.price
     return (
       <div className="listing-detail">
         {this.state.step===this.STEP.METAMASK &&
@@ -134,7 +135,7 @@ class ListingsDetail extends Component {
                 <div>
                   <span>Price</span>
                   <span className="price">
-                    {Number(this.state.price).toLocaleString(undefined, {minimumFractionDigits: 3})} ETH
+                    {Number(price).toLocaleString(undefined, {minimumFractionDigits: 3})} ETH
                   </span>
                 </div>
                 {(this.state.unitsAvailable > 1) &&


### PR DESCRIPTION
The price is set to the string `"Loading..."` by default. Because the
announcement form does not have a price field, this string is used in
the price display in the listing preview. The string is converted to the
number `NaN` when rendered.

With this change, the price is just displayed as 0 (the value that will
get stored on the listing contract and displayed once the listing is
created).

Not sure this is the best way to fix the issue, but it seemed like the simplest solution (as opposed to a more robust but complex solution that would require some refactoring).

### Before
<img width="653" alt="screen shot 2018-02-24 at 12 01 17 am" src="https://user-images.githubusercontent.com/6504519/36626838-2765c81a-18f7-11e8-8956-9d0c19700387.png">

### After
<img width="644" alt="screen shot 2018-02-24 at 12 01 41 am" src="https://user-images.githubusercontent.com/6504519/36626840-2ea31dda-18f7-11e8-9ea6-db5a3d62574e.png">

