### PR TITLE
Issue/19 set up docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:8
+ENV NPM_CONFIG_LOGLEVEL warn
+WORKDIR /src
+COPY package.json /src/
+COPY package-lock.json /src/
+COPY truffle.js /src/
+COPY contracts /src/contracts/
+COPY migrations /src/migrations/
+COPY bin/docker-truffle.sh /bin/docker-truffle.sh
+RUN npm install
+RUN npm install -g truffle
+RUN truffle compile

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ npm run start
 
 13. Try it! Create a listing and post it to IPFS and Ethereum.
 
+### Using Docker
+
+1. Start container:
+```
+docker-compose up -d
+```
+
+2. Set up Metamask using steps 6-10 above.
+
+3. Visit http://localhost:3000 in your browser.
+
 ## Get involved
 
 We'd love to have you join us on this project.  We're still in the super early stages, but join our [Discord channel](https://discord.gg/jyxpUSe) or [email us](mailto:founders@originprotocol.com) to get started.

--- a/bin/docker-truffle.sh
+++ b/bin/docker-truffle.sh
@@ -1,0 +1,2 @@
+# Start truffle develop, run migrate in the console, and prevent Docker from stopping the process.
+sleep infinity | (echo migrate && cat) | truffle develop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  node:
+    image: node:8
+    build: .
+    working_dir: /src
+    volumes:
+      - .:/src
+    ports:
+      - "3000:3000"
+    command: npm run start
+  truffle:
+    image: node:8
+    working_dir: /src
+    ports:
+      - "9545:9545"
+    command: bash /bin/docker-truffle.sh


### PR DESCRIPTION
Proposed fix for: https://github.com/OriginProtocol/demo-dapp/issues/19

Both truffle and the node server are started with one command. The source code is loaded as a volume, so it can be used as a development environment (changing a source file on the development machine will change the file in the container).