### PR TITLE
Issue/99 web3 account flickering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4020,6 +4020,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4028,14 +4036,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6555,7 +6555,6 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.7.1.tgz",
       "integrity": "sha512-r1grvv6mcEt+nlMzMWPc5n/z5q8NNuBWj0TGFp1PBSFCl6ubnAoUGBsucYsnZYT7MOJn0ha1ptEjmdBoAdJ+SA==",
       "requires": {
-        "JSONStream": "1.3.2",
         "abbrev": "1.1.1",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
@@ -6590,6 +6589,7 @@
         "ini": "1.3.5",
         "init-package-json": "1.10.1",
         "is-cidr": "1.0.0",
+        "JSONStream": "1.3.2",
         "lazy-property": "1.0.0",
         "libcipm": "1.3.3",
         "libnpx": "9.7.1",
@@ -6664,24 +6664,6 @@
         "write-file-atomic": "2.1.0"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.2",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            }
-          }
-        },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
@@ -7073,6 +7055,24 @@
           "dependencies": {
             "cidr-regex": {
               "version": "1.0.6",
+              "bundled": true
+            }
+          }
+        },
+        "JSONStream": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
               "bundled": true
             }
           }
@@ -11820,12 +11820,6 @@
         "warning": "3.0.0"
       }
     },
-    "react-web3": {
-      "version": "github:wanderingstan/react-web3#809d2493320663ee19b48eff86a49026380a6653",
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -12657,6 +12651,14 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -12666,14 +12668,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "react-js-pagination": "^3.0.1",
     "react-jsonschema-form": "^1.0.1",
     "react-router": "^4.2.0",
-    "react-router-dom": "^4.2.2",
-    "react-web3": "github:wanderingstan/react-web3#state_didchange_fix"
+    "react-router-dom": "^4.2.2"
   },
   "scripts": {
     "start": "node scripts/start.js",

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -3,17 +3,15 @@ import {
   BrowserRouter as Router,
   Route
 } from 'react-router-dom'
-import { Web3Provider } from 'react-web3'
 
 // Components
-import ScrollToTop from './scroll-to-top.js'
-import Listings from './listings-grid.js'
-import ListingDetail from './listing-detail.js'
-import ListingCreate from './listing-create.js'
-import Login from './login.js'
-import Footer from './footer'
-import NavBar from './navbar'
-import Overlay from './overlay'
+import ScrollToTop from './scroll-to-top'
+import Layout from './layout'
+import Listings from './listings-grid'
+import ListingDetail from './listing-detail'
+import ListingCreate from './listing-create'
+import Login from './login'
+import Web3Provider from './web3-provider'
 
 // CSS
 import '../css/pure-min.css' // TODO (stan): Is this even used?
@@ -52,46 +50,11 @@ const CreateListingPage = (props) => (
   </Layout>
 )
 
-const AccountUnavailableScreen = (props) => (
-  <Layout {...props}>
-    <Overlay imageUrl="/images/flat_cross_icon.svg">
-      You are not signed in to MetaMask.<br />
-    </Overlay>
-    <div className="container empty-page" />
-  </Layout>
-)
-
-const Web3UnavailableScreen = (props) => (
-  <Layout {...props}>
-    <Overlay imageUrl="/images/flat_cross_icon.svg">
-      MetaMask extension not installed.<br />
-      <a target="_blank" href="https://metamask.io/">Get MetaMask</a><br />
-      <a target="_blank" href="https://medium.com/originprotocol/origin-demo-dapp-is-now-live-on-testnet-835ae201c58">
-        Full Instructions for Demo
-      </a>
-    </Overlay>
-    <div className="container empty-page" />
-  </Layout>
-)
-
-const Layout = ({ children, hideCreateButton, hideLoginButton }) => (
-  <div>
-    <main>
-      <NavBar hideCreateButton={hideCreateButton} hideLoginButton={hideLoginButton} />
-      {children}
-    </main>
-    <Footer />
-  </div>
-)
-
 // Top level component
 const App = () => (
   <Router>
     <ScrollToTop>
-      <Web3Provider
-        web3UnavailableScreen={() => <Web3UnavailableScreen />}
-        accountUnavailableScreen={() => <AccountUnavailableScreen />}
-      >
+      <Web3Provider>
         <div>
           <Route exact path="/" component={HomePage}/>
           <Route path="/page/:activePage" component={HomePage}/>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import Footer from './footer'
+import NavBar from './navbar'
+
+const Layout = ({ children, hideCreateButton, hideLoginButton }) => (
+  <div>
+    <main>
+      <NavBar hideCreateButton={hideCreateButton} hideLoginButton={hideLoginButton} />
+      {children}
+    </main>
+    <Footer />
+  </div>
+)
+
+export default Layout

--- a/src/components/listings-grid.js
+++ b/src/components/listings-grid.js
@@ -11,7 +11,7 @@ const alertify = require('../../node_modules/alertify/src/alertify.js')
 
 class ListingsGrid extends Component {
 
-  constructor(props, context) {
+  constructor(props) {
     super(props)
     this.state = {
       listingIds: [],

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,38 +1,5 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import Overlay from './overlay'
-import PropTypes from 'prop-types'
-
-
-function NetworkCheck(props, context) {
-  const web3Context = context.web3
-  const networkNames = {
-    1: "Main",
-    2: "Morden",
-    3: "Ropsten",
-    4: "Rinkeby",
-    42: "Kovan"
-  }
-  const supportedNetworkIds = [3, 4]
-  const currentNetworkId = parseInt(web3Context.networkId, 10)
-  const currentNetworkName = (networkNames[currentNetworkId] ?
-    networkNames[currentNetworkId] : currentNetworkId)
-  if (currentNetworkId &&
-    (window.location.hostname === "demo.originprotocol.com") &&
-    (supportedNetworkIds.indexOf(currentNetworkId) < 0)) {
-    return (
-      <Overlay imageUrl="/images/flat_cross_icon.svg">
-        MetaMask should be on <strong>Rinkeby</strong> Network<br />
-        Currently on {currentNetworkName}.
-      </Overlay>
-    )
-  }
-  else return null
-}
-
-NetworkCheck.contextTypes = {
-  web3: PropTypes.object
-}
 
 const NavBar = (props) => {
   return (
@@ -45,7 +12,6 @@ const NavBar = (props) => {
               className="origin-logo" alt="Origin Protocol" />
           </div>
         </Link>
-        <NetworkCheck />
         {!props.hideCreateButton &&
           <div className="navbar-create">
             <Link to="/create">
@@ -66,4 +32,3 @@ const NavBar = (props) => {
 }
 
 export default NavBar
-export { NetworkCheck }

--- a/src/components/web3-provider.js
+++ b/src/components/web3-provider.js
@@ -1,0 +1,197 @@
+import React, { Component } from 'react'
+import Layout from './layout'
+import Overlay from './overlay'
+
+const alertify = require('../../node_modules/alertify/src/alertify.js')
+
+const networkNames = {
+  1: "Main",
+  2: "Morden",
+  3: "Ropsten",
+  4: "Rinkeby",
+  42: "Kovan",
+}
+const supportedNetworkIds = [3, 4]
+const ONE_SECOND = 1000
+const ONE_MINUTE = ONE_SECOND * 60
+
+const AccountUnavailable = (props) => (
+  <div>
+    <Layout {...props}>
+      <Overlay imageUrl="/images/flat_cross_icon.svg">
+        You are not signed in to MetaMask.<br />
+      </Overlay>
+    </Layout>
+  </div>
+)
+
+// TODO (micah): potentially add a loading indicator
+const Loading = (props) => (
+  <div>
+    <Layout {...props}>
+    </Layout>
+  </div>
+)
+
+const UnsupportedNetwork = (props) => (
+  <div>
+    <Layout {...props}>
+      <Overlay imageUrl="/images/flat_cross_icon.svg">
+        MetaMask should be on <strong>Rinkeby</strong> Network<br />
+        Currently on {props.currentNetworkName}.
+      </Overlay>
+    </Layout>
+  </div>
+)
+
+const Web3Unavailable = (props) => (
+  <div>
+    <Layout {...props}>
+      <Overlay imageUrl="/images/flat_cross_icon.svg">
+        MetaMask extension not installed.<br />
+        <a target="_blank" href="https://metamask.io/">Get MetaMask</a><br />
+        <a target="_blank" href="https://medium.com/originprotocol/origin-demo-dapp-is-now-live-on-testnet-835ae201c58">
+          Full Instructions for Demo
+        </a>
+      </Overlay>
+    </Layout>
+  </div>
+)
+
+class Web3Provider extends Component {
+  constructor(props) {
+    super(props)
+
+    this.interval = null
+    this.networkInterval = null
+    this.fetchAccounts = this.fetchAccounts.bind(this)
+    this.fetchNetwork = this.fetchNetwork.bind(this)
+    this.state = {
+      accounts: [],
+      accountsLoaded: false,
+      networkId: null,
+      networkError: null,
+    }
+  }
+
+  /**
+   * Start polling accounts, & network. We poll indefinitely so that we can
+   * react to the user changing accounts or networks.
+   */
+  componentDidMount() {
+    this.fetchAccounts()
+    this.fetchNetwork()
+    this.initPoll()
+    this.initNetworkPoll()
+  }
+
+  /**
+   * Init web3/account polling, and prevent duplicate interval.
+   * @return {void}
+   */
+  initPoll() {
+    if (!this.interval) {
+      this.interval = setInterval(this.fetchAccounts, ONE_SECOND)
+    }
+  }
+
+  /**
+   * Init network polling, and prevent duplicate intervals.
+   * @return {void}
+   */
+  initNetworkPoll() {
+    if (!this.networkInterval) {
+      this.networkInterval = setInterval(this.fetchNetwork, ONE_MINUTE)
+    }
+  }
+
+  /**
+   * Update state regarding the availability of web3 and an ETH account.
+   * @return {void}
+   */
+  fetchAccounts() {
+    const { web3 } = window
+
+    web3 && web3.eth && web3.eth.getAccounts((err, accounts) => {
+      if (!this.state.accountsLoaded) {
+        this.setState({ accountsLoaded: true })
+      }
+
+      if (err) {
+        console.log(err)
+
+        this.setState({ accountsError: err })
+      } else {
+        this.handleAccounts(accounts)
+      }
+    });
+  }
+
+  handleAccounts(accounts) {
+    let next = accounts[0]
+    let curr = this.state.accounts[0]
+    next = next && next.toLowerCase()
+    curr = curr && curr.toLowerCase()
+
+    if (curr !== next) {
+      curr && alertify.log('MetaMask account has changed.')
+
+      this.setState({
+        accountsError: null,
+        accounts,
+      })
+    }
+  }
+
+  /**
+   * Get the network and update state accordingly.
+   * @return {void}
+   */
+  fetchNetwork() {
+    const { web3 } = window
+
+    web3 && web3.version && web3.version.getNetwork((err, netId) => {
+      const networkId = parseInt(netId, 10)
+
+      if (err) {
+        this.setState({
+          networkError: err,
+        })
+      } else {
+        if (networkId !== this.state.networkId) {
+          this.setState({
+            networkError: null,
+            networkId,
+          })
+        }
+      }
+    })
+  }
+
+  render() {
+    const { web3 } = window
+    const { accounts, accountsLoaded, networkId } = this.state
+    const currentNetworkName = networkNames[networkId] ? networkNames[networkId] : networkId
+    const inProductionEnv = window.location.hostname === 'demo.originprotocol.com'
+
+    if (!web3) {
+      return <Web3Unavailable />
+    }
+
+    if (networkId && inProductionEnv && (supportedNetworkIds.indexOf(networkId) < 0)) {
+      return <UnsupportedNetwork currentNetworkName={currentNetworkName} />
+    }
+
+    if (!accountsLoaded) {
+      return <Loading />
+    }
+
+    if (!accounts.length) {
+      return <AccountUnavailable />
+    }
+
+    return this.props.children
+  }
+}
+
+export default Web3Provider

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -38,7 +38,7 @@ body {
 }
 
 /* sticky footer parent */
-#root > div > div > div {
+#root > div > div {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -47,6 +47,7 @@ body {
 /* sticky footer sibling */
 main {
   flex: 1 0 auto;
+  min-height: 100vh;
 }
 
 /* Common */
@@ -196,12 +197,6 @@ a:hover {
   border: solid 1px var(--light);
   background-color: white;
   color: var(--clear-blue);
-}
-
-/* Special case when we need to render an empty page,
-   but keep footer from toucher navbar */
-.empty-page {
-  height: 800px;
 }
 
 /* Listings */


### PR DESCRIPTION
This resolves #99 and simplifies the web3 integration. This removes an external package dependency, which, among other things:

**Previously**
- required the maintenance of an external fork
- included unnecessary Redux integration
- injected unused styles
- depended on Lodash
- used React [context](https://reactjs.org/docs/context.html#why-not-to-use-context)

**Considerations**

1. We were already _blocking the UI_ when (a) web3 was unavailable, (b) the user was logged out, or (c) the selected network was unsupported. However, we were only _preventing the route-specific rendering_ (listings, forms, etc) in cases (a) and (b). So if the selected network was unsupported, a user could easily remove the overlay elements and engage the web3-dependent functions. If it is preferable for all of that route-specific UI to exist and be visible behind the overlay when an unsupported network is selected, then a different rendering strategy should be used rather than the one that this PR inherits from `react-web3` (multiple conditioned return statements). Aside from this consideration, 45e30d584ae2bcb498a25c6d2a5e2b27208bc2ec at least moves that network logic out of the navbar component and into the`Web3Provider` component.
2. One consequence of this PR is that it makes the provider component code more specific to our use case (and UI), which is less modular. I think the long-term goal is to make the DApp code more modular and perhaps separate UI concerns from others. But I think the appropriate first step is to simplify the code and remove the external package dependency, as this PR does.
3. At some point in the relatively near future, [web3.js 1.0](https://github.com/ethereum/web3.js/pull/558) will be released. This may be yet another reason to not deal with an external package dependency and rather implement our own provider component.
