### PR TITLE
Don't parse JSON from IPFS twice

### DIFF
--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -36,9 +36,8 @@ class ListingsDetail extends Component {
       this.setState(listingContractObject)
       return ipfsService.getListing(this.state.ipfsHash)
     })
-    .then((listingJson) => {
-      const jsonData = JSON.parse(listingJson).data
-      this.setState(jsonData)
+    .then(({ data }) => {
+      this.setState(data)
     })
     .catch((error) => {
       alertify.log('There was an error loading this listing.')


### PR DESCRIPTION
Origin.js was changed to parse the JSON on retrieval in https://github.com/OriginProtocol/platform/commit/4187d47a7fb7eb7ab720a27f0e0ef8617c4b353a#diff-ff15870115f22edd2922952fe9681678

This is an update of the demo-dapp so we don't try to parse the JSON twice.

It still has a reference to the `data` property from the response even though the `data` property comes from [OriginService](https://github.com/OriginProtocol/platform/blob/develop/packages/origin.js/src/origin-service.js#L11). This isn't ideal and the `data` property should be hidden from the library consumers.