### PR TITLE
Create origin service which exports an instantiated Origin class

### DIFF
--- a/src/components/listing-card.js
+++ b/src/components/listing-card.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 
 // temporary - we should be getting an origin instance from our app,
 // not using a global singleton
-import origin from '@originprotocol/origin'
+import origin from '../services/origin'
 
 class ListingCard extends Component {
 

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
-import origin from '@originprotocol/origin'
+import origin from '../services/origin'
 
 import ListingDetail from './listing-detail'
 import Form from 'react-jsonschema-form'

--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -4,7 +4,7 @@ import Modal from './modal'
 
 // temporary - we should be getting an origin instance from our app,
 // not using a global singleton
-import origin from '@originprotocol/origin' 
+import origin from '../services/origin' 
 
 const alertify = require('../../node_modules/alertify/src/alertify.js')
 

--- a/src/components/listings-grid.js
+++ b/src/components/listings-grid.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import origin from '@originprotocol/origin'
+import origin from '../services/origin'
 
 import Pagination from 'react-js-pagination'
 import { withRouter } from 'react-router'

--- a/src/services/origin.js
+++ b/src/services/origin.js
@@ -1,0 +1,3 @@
+import Origin from '@originprotocol/origin'
+
+export default new Origin()


### PR DESCRIPTION
https://github.com/OriginProtocol/platform/pull/82 will break the demo dapp without this PR. Because the origin service is now a class that must be instantiated, and because we only want to instantiate it once in the entire app, I opted to create this service which instantiates the class and then exports the instance to make it available to the rest of the app.