### PR TITLE
Updating Readme per one-line-to-rule-them-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,21 @@
 ![origin_github_banner](https://user-images.githubusercontent.com/673455/37314301-f8db9a90-2618-11e8-8fee-b44f38febf38.png)
 
 # Origin Demo DApp
-The sharing economy without intermediaries.
+This is an examle DApp (Decentralized Application) that shows how easy it is to create a decentralized marketplace on the ethereum blockchain. It showcases the power of [origin.js](https://github.com/OriginProtocol/platform).  Using only javascript commands, you can search listings, create listings, purchase listings, and more. 
 
-NOTE 2018-03-11: We are in the midst of transitioning this demo to use our `origin.js` library. This work is currently on the `develop` branch but will soon be merged.
-
-## Project Overview
-
-Origin is a sharing economy marketplace that enables buyers and sellers of fractional use goods and services (car-sharing, service-based tasks, home-sharing, etc.) to transact on the distributed, open web. Using the Ethereum blockchain and Interplanetary File System (IPFS), the platform and community are decentralized, allowing for the creation and booking of services and goods without traditional intermediaries.
-
-We are specifically building a large-scale commerce network that:
-* Transfers direct financial value (listing, transaction, and service fees) from large corporations like Airbnb, Craigslist, Postmates, etc. to individual buyers and sellers
-* Transfers indirect financial and strategic value (privately aggregated silos of customer and transaction data) from those same corporations to the entire ecosystem
-* Creates new financial value for marketplace participants that contribute to the growth of the network (e.g. building new technology for the Origin network, bootstrapping new product verticals, and referring new users and businesses)
-* Is built on an open, distributed, and shared data layer to promote transparency and collaboration
-* Immediately allows buyers and sellers across the world to do business with each other without difficult currency conversions or tariffs
-* Promotes personal liberty by not allowing a central corporation or government to impose arbitrary and oftentimes onerous rules on how to do business
-
-To accomplish these ambitious goals, the Origin platform is being launched with incentives from the outset to encourage other technologists, businesses, and consumers to build, contribute, and extend the ecosystem with us. We imagine a broad collection of vertical use cases (e.g short-term vacation rentals, freelance software engineering, tutoring for hire) that are built on top of Origin standards and shared data. Together, we will create the Internet economy of tomorrow.
+Documentation for origin.js is located here: http://docs.originprotocol.com/
 
 To learn more about this project, please visit [the Origin website](https://www.originprotocol.com) and download our whitepaper.
 
+*NOTE:* This project is under rapid development. 
+
 ## Try Demo Dapp on the Rinkeby testnet
 
-This demo is currently running on the Rinkeby testnet.
+This demo is currently running on the Rinkeby testnet. (Note that this demo is slightly behind the current state of this repo.) 
 - [Overview and step-by-step instructions](https://medium.com/originprotocol/origin-demo-dapp-is-now-live-on-testnet-835ae201c58)
 - [Live Demo](http://demo.originprotocol.com)
 
-
-## Core Technologies
-
-If you're new to the space, it may be helpful to first familiarize yourself with some of the core technologies that we're using to build Origin.
-
- * [JSON Schema](http://json-schema.org/)
- * [IPFS](https://ipfs.io/)
- * [Ethereum](https://www.ethereum.org/)
-
 ## Install and run Demo DApp locally
-
-NOTE: This installs the DApp locally for use with the Rinkeby and Ropsten test nets. See below for developing with a local test chain or for hosting on a server. If you need some Rinkeby eth, you can get some at [this faucet](https://faucet.rinkeby.io/).
 
 ### 1. Check node version
 
@@ -71,10 +48,17 @@ A browser will open to http://localhost:3000. You're not quite done though! You'
 
    **Be careful not to mix up your test wallet with your real one on the Main Network.**
 
+### 4. Get some test ether
+
+   - To get some Rinkeby ETH for creating or purchasing listings, visit the [this faucet](https://faucet.rinkeby.io/).
+
 ### 4. Try it!
 Create a listing and post it to IPFS and Ethereum.
 
+
 ## Developing with a local chain
+
+By default, this demo will connect to the global test networks of Rinkeby or Ropsten. For development, you may wish to connect to a local blockchain running on your local machine. 
 
 ### 1. Set up and run *origin.js* locally
 


### PR DESCRIPTION
## Problem trying to solve

Readme long and chaotic, and not tailored to our target demographics: 
- Web developers who don't know about blockchain but want to create a marketplace
- People interested in blockchain development who are installing demo-dapp in order to work on origin.js

# Overview of the suggested solution
- Move company mission and technical verbiage to developer landing page or origin.js repo

This is a first stab at improving. Additional commits and comments welcome. 