### PR TITLE
🔧 Use listing address in listing detail URL.

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -35,7 +35,7 @@ const HomePage = (props) => (
 )
 
 const ListingDetailPage = (props) => (
-  <ListingDetail listingId={props.match.params.listingId} />
+  <ListingDetail listingAddress={props.match.params.listingAddress} />
 )
 
 const CreateListingPage = (props) => (
@@ -81,7 +81,7 @@ const App = () => (
           <Switch>
             <Route exact path="/" component={HomePage} />
             <Route path="/page/:activePage" component={HomePage} />
-            <Route path="/listing/:listingId" component={ListingDetailPage} />
+            <Route path="/listing/:listingAddress" component={ListingDetailPage} />
             <Route path="/create" component={CreateListingPage} />
             <Route path="/my-listings" component={MyListingsPage} />
             <Route path="/my-purchases/:listingId" component={MyPurchasesTransactionPage} />

--- a/src/components/listing-card.js
+++ b/src/components/listing-card.js
@@ -28,7 +28,7 @@ class ListingCard extends Component {
   render() {
     return (
       <div className={`col-12 col-md-6 col-lg-4 listing-card${this.state.loading ? ' loading' : ''}`}>
-        <Link to={`/listing/${this.props.listingId}`}>
+        <Link to={`/listing/${this.state.address}`}>
           <div className="photo" style={{backgroundImage:`url("${
             (this.state.pictures && this.state.pictures.length>0 &&
               (new URL(this.state.pictures[0])).protocol === "data:") ?

--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -36,18 +36,18 @@ class ListingsDetail extends Component {
 
   async loadListing() {
     try {
-      const listing = await origin.listings.getByIndex(this.props.listingId)
+      const listing = await origin.listings.get(this.props.listingAddress)
       const obj = Object.assign({}, listing, { loading: false, reviews: data.reviews })
-
       this.setState(obj)
     } catch (error) {
       alertify.log('There was an error loading this listing.')
-      console.error(`Error fetching contract or IPFS info for listingId: ${this.props.listingId}`)
+      console.error(`Error fetching contract or IPFS info for listing: ${this.props.listingAddress}`)
+      console.log(error)
     }
   }
 
   componentWillMount() {
-    if (this.props.listingId) {
+    if (this.props.listingAddress) {
       // Load from IPFS
       this.loadListing()
     }
@@ -170,12 +170,12 @@ class ListingsDetail extends Component {
                                 </div> */}
                 {!this.state.loading &&
                   <div>
-                    {(this.props.listingId) && (
+                    {(this.state.address) && (
                       (this.state.unitsAvailable > 0) ?
                         <button
                           className="button"
                           onClick={this.handleBuyClicked}
-                          disabled={!this.props.listingId}
+                          disabled={!this.state.address}
                           onMouseDown={e => e.preventDefault()}
                         >
                           Buy Now


### PR DESCRIPTION
### Description:

See https://github.com/OriginProtocol/origin-js/issues/112 for the issue this fixes.

- Use listing address in listing detail URL.
- Get listing by address using new Listing.get API

This requires https://github.com/OriginProtocol/origin-js/pull/113 on the origin-js side.

### Checklist:

- [x] Test your work and double check you didn't break anything
