### PR TITLE
Remove fixed height from root container

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -16,10 +16,6 @@ body {
   font-family: var(--default-font);
 }
 
-#root {
-  height: 100%;
-}
-
 /* sticky footer sibling */
 main {
   flex: 1 0 auto;


### PR DESCRIPTION
This fixes an issue with excess white space appearing below the footer on small screens. I think the code was a remnant of a prior iteration of the sticky footer. After 22b09fb, the footer will still stick below the viewport on empty pages.

_This branch is currently visible at http://demo-micah.herokuapp.com/_ ✅