### PR TITLE
Tyleryasaka/config defaults

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,5 @@
+ATTESTATION_SERVER_URL=https://dev.bridge.originprotocol.com/api/attestations
+IPFS_API_PORT=5002
+IPFS_DOMAIN=localhost
+IPFS_GATEWAY_PORT=8080
+IPFS_GATEWAY_PROTOCOL=http

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ In a separate tab:
 git clone https://github.com/OriginProtocol/demo-dapp origin-demo-dapp && cd origin-demo-dapp
 npm run install:dev
 npm run start
+cp .env.dev .env
 ```
 
 The `install:dev` script performs the regular install and then links to your local origin.js.

--- a/src/services/origin.js
+++ b/src/services/origin.js
@@ -5,9 +5,7 @@ let config = {
   ipfsApiPort: process.env.IPFS_API_PORT || undefined,
   ipfsGatewayPort: process.env.IPFS_GATEWAY_PORT || undefined,
   ipfsGatewayProtocol: process.env.IPFS_GATEWAY_PROTOCOL || undefined,
-  attestationServerUrl:
-    process.env.ATTESTATION_SERVER_URL ||
-    'https://dev.bridge.originprotocol.com/api/attestations'
+  attestationServerUrl: process.env.ATTESTATION_SERVER_URL || undefined
 }
 
 try {

--- a/src/services/origin.js
+++ b/src/services/origin.js
@@ -1,11 +1,11 @@
 import Origin from 'origin'
 
 let config = {
-  ipfsDomain: process.env.IPFS_DOMAIN || undefined,
-  ipfsApiPort: process.env.IPFS_API_PORT || undefined,
-  ipfsGatewayPort: process.env.IPFS_GATEWAY_PORT || undefined,
-  ipfsGatewayProtocol: process.env.IPFS_GATEWAY_PROTOCOL || undefined,
-  attestationServerUrl: process.env.ATTESTATION_SERVER_URL || undefined
+  ipfsDomain: process.env.IPFS_DOMAIN,
+  ipfsApiPort: process.env.IPFS_API_PORT,
+  ipfsGatewayPort: process.env.IPFS_GATEWAY_PORT,
+  ipfsGatewayProtocol: process.env.IPFS_GATEWAY_PROTOCOL,
+  attestationServerUrl: process.env.ATTESTATION_SERVER_URL
 }
 
 try {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,14 +9,6 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const isProduction = process.env.NODE_ENV === 'production'
 
 const env = { CONTRACT_ADDRESSES: '{}' }
-if (!isProduction) {
-  Object.assign(env, {
-    IPFS_DOMAIN: 'localhost',
-    IPFS_API_PORT: 5002,
-    IPFS_GATEWAY_PORT: 8080,
-    IPFS_GATEWAY_PROTOCOL: 'http'
-  })
-}
 
 var config = {
   entry: { app: './src/index.js' },


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double check you didn't break anything
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

It's been clarified already that we want the demo dapp to work out of the box on the test net, without any other local dependencies (local blockchain, local origin.js, local IPFS).

That said, we also want to make it as easy as possible to do local development.

So, with this config:
- Out of the box there are no local dependencies
- To get local development config, just `cp .env.dev .env`
