### PR TITLE
Identity link

### DIFF
--- a/src/pages/profile/Profile.js
+++ b/src/pages/profile/Profile.js
@@ -276,6 +276,7 @@ class Profile extends Component {
               <Wallet
                 balance={this.props.balance}
                 address={this.props.address}
+                identityAddress={this.props.identityAddress}
               />
               <Guidance />
             </div>
@@ -448,7 +449,8 @@ const mapStateToProps = state => {
     provisionalProgress: state.profile.provisionalProgress,
     publishedProgress: state.profile.publishedProgress,
     profile: state.profile,
-    balance: state.wallet.balance
+    balance: state.wallet.balance,
+    identityAddress: state.profile.user.identityAddress,
   }
 }
 

--- a/src/pages/profile/_Wallet.js
+++ b/src/pages/profile/_Wallet.js
@@ -30,9 +30,11 @@ class Wallet extends Component {
             <a onClick={() => alert('To do')}>ETH</a> | <a onClick={() => alert('To do')}>Tokens</a>
           </div>
         </div>
-        <div>
-          <a href={`https://erc725.originprotocol.com/#/identity/${identityAddress}`} target="_blank">Identity Contract Detail</a>
-        </div>
+        {identityAddress &&
+          <div>
+            <a href={`https://erc725.originprotocol.com/#/identity/${identityAddress}`} target="_blank">Identity Contract Detail</a>
+          </div>
+        }
       </div>
     )
   }

--- a/src/pages/profile/_Wallet.js
+++ b/src/pages/profile/_Wallet.js
@@ -4,13 +4,13 @@ import Identicon from 'components/Identicon'
 
 class Wallet extends Component {
   render() {
-    var address = this.props.address
+    const { address, balance, identityAddress } = this.props
 
     return (
       <div className="wallet">
         <div className="d-flex">
           <div className="image-container">
-            <Identicon address={this.props.address} />
+            <Identicon address={address} />
           </div>
           <div className="eth d-flex flex-column justify-content-between">
             <div>ETH Address:</div>
@@ -22,13 +22,16 @@ class Wallet extends Component {
         <hr className="dark sm" />
         <div className="detail d-flex">
           <div>Account Balance:</div>
-          <div>{this.props.balance} ETH</div>
+          <div>{balance} ETH</div>
         </div>
         <div className="detail d-flex">
           <div>Transaction History:</div>
           <div>
             <a onClick={() => alert('To do')}>ETH</a> | <a onClick={() => alert('To do')}>Tokens</a>
           </div>
+        </div>
+        <div>
+          <a href={`https://erc725.originprotocol.com/#/identity/${identityAddress}`} target="_blank">Identity Contract Detail</a>
         </div>
       </div>
     )


### PR DESCRIPTION
This adds a link to the raw identity data in the wallet to satisfy #158. It uses the hard-coded hostname `erc725.originprotocol.com` in the link. This should be merged after https://github.com/OriginProtocol/origin-js/pull/188.