### PR TITLE
Issue #62 - Handle MetaMask errors and allow user to reset state

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -35,7 +35,7 @@ const HomePage = () => (
 )
 
 const ListingDetailPage = props => (
-  <ListingDetail listingAddress={props.match.params.listingAddress} />
+  <ListingDetail listingAddress={props.match.params.listingAddress} withReviews={true} />
 )
 
 const CreateListingPage = () => (

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -25,7 +25,8 @@ class ListingCreate extends Component {
       PREVIEW: 3,
       METAMASK: 4,
       PROCESSING: 5,
-      SUCCESS: 6
+      SUCCESS: 6,
+      ERROR: 7
     }
 
     this.schemaList = [
@@ -111,10 +112,13 @@ class ListingCreate extends Component {
       await origin.contractService.waitTransactionFinished(transactionReceipt.transactionHash)
       this.setState({ step: this.STEP.SUCCESS })
     } catch (error) {
-      // TODO: We need a failure step to go to here
       console.error(error)
-      this.props.showAlert(error.message)
+      this.setState({ step: this.STEP.ERROR })
     }
+  }
+
+  resetToStepOne() {
+    this.setState({ step: this.STEP.PICK_SCHEMA })
   }
 
   render() {
@@ -218,6 +222,23 @@ class ListingCreate extends Component {
                 <Link to="/">See All Listings</Link>
               </Modal>
             }
+            {this.state.step === this.STEP.ERROR && (
+              <Modal backdrop="static" isOpen={true}>
+                <div className="image-container">
+                  <img src="images/flat_cross_icon.svg" role="presentation" />
+                </div>
+                There was a problem creating this listing.<br />See the console for more details.<br />
+                <a
+                  href="#"
+                  onClick={e => {
+                    e.preventDefault()
+                    this.resetToStepOne()
+                  }}
+                >
+                  OK
+                </a>
+              </Modal>
+            )}
             <div className="row">
               <div className="col-md-7">
                 <label className="create-step">STEP {Number(this.state.step)}</label>

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -117,8 +117,8 @@ class ListingCreate extends Component {
     }
   }
 
-  resetToStepOne() {
-    this.setState({ step: this.STEP.PICK_SCHEMA })
+  resetToPreview() {
+    this.setState({ step: this.STEP.PREVIEW })
   }
 
   render() {
@@ -232,7 +232,7 @@ class ListingCreate extends Component {
                   href="#"
                   onClick={e => {
                     e.preventDefault()
-                    this.resetToStepOne()
+                    this.resetToPreview()
                   }}
                 >
                   OK

--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -23,6 +23,7 @@ class ListingsDetail extends Component {
       METAMASK: 2,
       PROCESSING: 3,
       PURCHASED: 4,
+      ERROR: 5
     }
 
     this.state = {
@@ -87,17 +88,20 @@ class ListingsDetail extends Component {
       this.setState({step: this.STEP.PURCHASED})
     } catch (error) {
       window.err = error
-      console.log(error)
-      this.props.showAlert("There was a problem purchasing this listing.\nSee the console for more details.")
-      this.setState({step: this.STEP.VIEW})
+      console.error(error)
+      this.setState({step: this.STEP.ERROR})
     }
+  }
+
+  resetToStepOne() {
+    this.setState({step: this.STEP.VIEW})
   }
 
 
   render() {
     return (
       <div className="listing-detail">
-        {this.state.step===this.STEP.METAMASK &&
+        {this.state.step === this.STEP.METAMASK &&
           <Modal backdrop="static" isOpen={true}>
             <div className="image-container">
               <img src="images/spinner-animation.svg" role="presentation"/>
@@ -106,7 +110,7 @@ class ListingsDetail extends Component {
             Press &ldquo;Submit&rdquo; in MetaMask window
           </Modal>
         }
-        {this.state.step===this.STEP.PROCESSING &&
+        {this.state.step === this.STEP.PROCESSING &&
           <Modal backdrop="static" isOpen={true}>
             <div className="image-container">
               <img src="images/spinner-animation.svg" role="presentation"/>
@@ -115,7 +119,7 @@ class ListingsDetail extends Component {
             Please stand by...
           </Modal>
         }
-        {this.state.step===this.STEP.PURCHASED &&
+        {this.state.step === this.STEP.PURCHASED &&
           <Modal backdrop="static" isOpen={true}>
             <div className="image-container">
               <img src="images/circular-check-button.svg" role="presentation"/>
@@ -129,6 +133,23 @@ class ListingsDetail extends Component {
             </a>
           </Modal>
         }
+        {this.state.step === this.STEP.ERROR && (
+          <Modal backdrop="static" isOpen={true}>
+            <div className="image-container">
+              <img src="images/flat_cross_icon.svg" role="presentation" />
+            </div>
+            There was a problem purchasing this listing.<br />See the console for more details.<br />
+            <a
+              href="#"
+              onClick={e => {
+                e.preventDefault()
+                this.resetToStepOne()
+              }}
+            >
+              OK
+            </a>
+          </Modal>
+        )}
         {(this.state.loading || (this.state.pictures && this.state.pictures.length)) &&
           <div className="carousel">
             {this.state.pictures.map(pictureUrl => (

--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -278,17 +278,19 @@ class ListingsDetail extends Component {
               {this.state.sellerAddress && <UserCard title="seller" userAddress={this.state.sellerAddress} />}
             </div>
           </div>
-          <div className="row">
-            <div className="col-12 col-md-8">
-              <hr />
-              <div className="reviews">
-                <h2>Reviews <span className="review-count">{buyersReviews.length}</span></h2>
-                {buyersReviews.map(r => <Review key={r.transactionHash} review={r} />)}
-                {/* To Do: pagination */}
-                {/* <a href="#" className="reviews-link">Read More<img src="/images/carat-blue.svg" className="down carat" alt="down carat" /></a> */}
+          {this.props.withReviews &&
+            <div className="row">
+              <div className="col-12 col-md-8">
+                <hr />
+                <div className="reviews">
+                  <h2>Reviews <span className="review-count">{buyersReviews.length}</span></h2>
+                  {buyersReviews.map(r => <Review key={r.transactionHash} review={r} />)}
+                  {/* To Do: pagination */}
+                  {/* <a href="#" className="reviews-link">Read More<img src="/images/carat-blue.svg" className="down carat" alt="down carat" /></a> */}
+                </div>
               </div>
             </div>
-          </div>
+          }
         </div>
       </div>
     )

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1365,7 +1365,7 @@ label[for=root_pictures]:hover {
   margin-bottom: 30px;
   display: block;
   width: 100%;
-  height: 720px;
+  min-height: 720px;
   border-radius: var(--default-radius);
   border: solid 1px var(--light);
 }


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double check you didn't break anything

### Description:

When a user rejects a transaction via the provider's popup window, demo-dapp needs to handle that gracefully and allow the user to reset the state of the app to remove the "waiting" modal. 

This PR uses the error modal styling from the Profile page and implements it on the "Create Listing" and "Listing Detail" pages. 
