### PR TITLE
Properly fall back to default bridge server url

### DIFF
--- a/src/services/origin.js
+++ b/src/services/origin.js
@@ -1,9 +1,12 @@
 import Origin from 'origin'
 
-const bridgeServerProtocol = process.env.BRIDGE_SERVER_PROTOCOL
-const bridgeServerDomain = process.env.BRIDGE_SERVER_DOMAIN
-const attestationServerUrl =
-`${bridgeServerProtocol}://${bridgeServerDomain}/api/attestations`
+const defaultBridgeUrl = "https://bridge.originprotocol.com"
+const bridgeProtocol = process.env.BRIDGE_SERVER_PROTOCOL
+const bridgeDomain = process.env.BRIDGE_SERVER_DOMAIN
+const customBridgeUrl = `${bridgeProtocol}://${bridgeDomain}`
+const hasCustomBridge = bridgeProtocol && bridgeDomain
+const bridgeUrl = hasCustomBridge ? customBridgeUrl : defaultBridgeUrl
+const attestationServerUrl = `${bridgeUrl}/api/attestations`
 
 const config = {
   ipfsDomain: process.env.IPFS_DOMAIN,


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double check you didn't break anything
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

Fixes an important bug discovered by @micahalcorn . We weren't properly falling back to the default bridge server url.