### PR TITLE
Hide static content

### DIFF
--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -207,7 +207,8 @@ class ListingsDetail extends Component {
                 <li>Seller: {this.state.sellerAddress}</li>
                 <li>Units: {this.state.unitsAvailable}</li>
               </div>
-              {!this.state.loading && this.state.purchases.length > 0 &&
+              {/* Hidden for current deployment */}
+              {/*!this.state.loading && this.state.purchases.length > 0 &&
                 <Fragment>
                   <hr />
                   <h2>Purchases</h2>
@@ -228,7 +229,7 @@ class ListingsDetail extends Component {
                     </tbody>
                   </table>
                 </Fragment>
-              }
+              */}
             </div>
             <div className="col-12 col-md-4">
               <div className="buy-box placehold">

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 
 import ConnectivityDropdown from 'components/dropdowns/connectivity'
-import NotificationsDropdown from 'components/dropdowns/notifications'
+// Hidden for current deployment
+// import NotificationsDropdown from 'components/dropdowns/notifications'
 import UserDropdown from 'components/dropdowns/user'
 
 class NavBar extends Component {
@@ -51,7 +52,8 @@ class NavBar extends Component {
           </div>
           <div className="static navbar-nav order-1 order-lg-2">
             <ConnectivityDropdown />
-            <NotificationsDropdown />
+            {/* Hidden for current deployment */}
+            {/* <NotificationsDropdown /> */}
             <UserDropdown />
           </div>
         </div>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -458,7 +458,9 @@ a:hover {
   position: absolute;
   content: '';
   height: 18px;
-  right: 130px;
+  /* Temporary shift for current deployment */
+  right: 70px;
+  /*right: 130px;*/
   top: 0;
   width: 36px;
   z-index: 999;
@@ -511,7 +513,9 @@ a:hover {
 }
 
 .connectivity .triangle {
-  margin-right: 130px;
+  /* Temporary shift for current deployment */
+  margin-right: 70px;
+  /*margin-right: 130px;*/
   width: 36px;
 
   -webkit-clip-path: polygon(50% 0, 0 100%, 100% 100%);
@@ -2623,7 +2627,9 @@ footer .footer-links li a {
   }
 
   .navbar .connectivity .dropdown-menu {
-    right: calc(((100% - 540px) / 2) + 60px + 60px);
+    /* Temporary shift for current deployment */
+    right: calc(((100% - 540px) / 2) + 60px);
+    /*right: calc(((100% - 540px) / 2) + 60px + 60px);*/
     /*width: calc(540px - 60px - 60px);*/
   }
 
@@ -2650,7 +2656,9 @@ footer .footer-links li a {
   }
 
   .navbar .connectivity .dropdown-menu {
-    right: calc(((100% - 720px) / 2) + 60px + 60px);
+    /* Temporary shift for current deployment */
+    right: calc(((100% - 720px) / 2) + 60px);
+    /*right: calc(((100% - 720px) / 2) + 60px + 60px);*/
     /*width: 520px;*/
   }
 
@@ -2740,7 +2748,9 @@ footer .footer-links li a {
   }
 
   .navbar .connectivity .dropdown-menu {
-    right: calc(((100% - 960px) / 2) + 60px + 60px + 15px);
+    /* Temporary shift for current deployment */
+    right: calc(((100% - 960px) / 2) + 60px + 15px);
+    /*right: calc(((100% - 960px) / 2) + 60px + 60px + 15px);*/
   }
 
   .navbar .identity .dropdown-menu {
@@ -2867,7 +2877,9 @@ footer .footer-links li a {
 /* xl + */
 @media (min-width: 1200px) {
   .navbar .connectivity .dropdown-menu {
-    right: calc(((100% - 1140px) / 2) + 60px + 60px + 15px);
+    /* Temporary shift for current deployment */
+    right: calc(((100% - 1140px) / 2) + 60px + 15px);
+    /*right: calc(((100% - 1140px) / 2) + 60px + 60px + 15px);*/
   }
 
   .navbar .identity .dropdown-menu {

--- a/src/pages/profile/_Wallet.js
+++ b/src/pages/profile/_Wallet.js
@@ -30,11 +30,12 @@ class Wallet extends Component {
             <a onClick={() => alert('To do')}>ETH</a> | <a onClick={() => alert('To do')}>Tokens</a>
           </div>
         </div>
-        {identityAddress &&
+        {/* Hidden for current deployment */}
+        {/* identityAddress &&
           <div>
             <a href={`https://erc725.originprotocol.com/#/identity/${identityAddress}`} target="_blank">Identity Contract Detail</a>
           </div>
-        }
+        */}
       </div>
     )
   }


### PR DESCRIPTION
This hides the notifications dropdown from the navbar and adjusts the CSS to accommodate the connectivity dropdown. It also removes the purchases table from the listing detail page.

Satisfies #148 & #187 in preparation for the current deployment ✅