### PR TITLE
Add build_webpack to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 .DS_Store
 build/
 .env
+
+# Build folders
+build_webpack/


### PR DESCRIPTION
build_webpack was in .gitignore back in december: https://github.com/OriginProtocol/demo-dapp/commit/538d9b6235598db348e7cce88be918aca2a373bf#diff-a084b794bc0759e7a6b77810e01874f2

Can't remember why we took it out. Seems there were some files in there that *did* need to be in git? @Nick? 

I just feel dirty always seeing this:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	build_webpack/
```

First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [ ] Test your work and double check you didn't break anything
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

Please explain the changes you made here:

- A description of the problem you're trying to solve
- An overview of the suggested solution
- If the feature changes current behavior, reasons why your solution is better
