### PR TITLE
hotfix/Pagination

### DIFF
--- a/src/components/listings-grid.js
+++ b/src/components/listings-grid.js
@@ -50,7 +50,7 @@ class ListingsGrid extends Component {
               ))}
             </div>
             <Pagination
-              activePage={activePage}
+              activePage={parseInt(activePage)}
               itemsCountPerPage={listingsPerPage}
               totalItemsCount={listingIds.length}
               pageRangeDisplayed={5}

--- a/src/components/listings-grid.js
+++ b/src/components/listings-grid.js
@@ -75,6 +75,4 @@ const mapDispatchToProps = dispatch => ({
   getListingIds: () => dispatch(getListingIds())
 })
 
-export default connect(mapStateToProps, mapDispatchToProps)(
-  withRouter(ListingsGrid)
-)
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ListingsGrid))


### PR DESCRIPTION
☑️ _This PR is intentionally pointed to `master` since it is a hotfix and we don't want to confuse this branch's package.json with `develop`'s (among other things)._

Pagination was not working because the [`wrapRouter` and `connect` wrappers were in the wrong order](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/guides/redux.md#blocked-updates).