### PR TITLE
Hotfix/zeros

### DIFF
--- a/src/components/listing-card.js
+++ b/src/components/listing-card.js
@@ -34,7 +34,7 @@ class ListingCard extends Component {
     return (
       <div className={`col-12 col-md-6 col-lg-4 listing-card${loading ? ' loading' : ''}`}>
         <Link to={`/listing/${address}`}>
-          {photo &&
+          {!!photo &&
             <div className="photo" style={{ backgroundImage: `url("${photo}")` }}></div>
           }
           {!photo &&


### PR DESCRIPTION
☑️ _This PR is intentionally pointed to master since it is a hotfix and we don't want to confuse this branch's package.json with develop's (among other things)._

As a result of https://github.com/OriginProtocol/demo-dapp/pull/199/commits/3bd9cd7523e800df7215b06dcc45c237067847ca#diff-a9103ca3b51d952e7ee2970ed96fbec9, listings without an image resulted in being prepended by 0️⃣s in the listing card. Zeros no more.

<img width="1920" alt="screen shot 2018-05-24 at 7 27 45 pm 2" src="https://user-images.githubusercontent.com/273937/40520063-0f04bcda-5f89-11e8-99a1-8e25b0731a77.png">
