### PR TITLE
Fix chrome bug where profile dropdown was invisible

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -2301,7 +2301,6 @@ sup {
   color: white;
   font-size: 0.875rem;
   font-weight: normal;
-  line-height: 1;
   padding: 20px;
 }
 


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double check you didn't break anything
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

This issue isn't occuring for @micahalcorn even though we're using the same version of Chrome. Since the issue is related to line height, we think it might (?) be related to machine font configuration. We're not sure, but we don't want to have css that only works for some people.

#### before
<img width="346" alt="screen shot 2018-05-25 at 11 00 59 am" src="https://user-images.githubusercontent.com/6504519/40561354-bc03b980-6011-11e8-9631-96b68a7e6499.png">

#### after
<img width="327" alt="screen shot 2018-05-25 at 11 18 44 am" src="https://user-images.githubusercontent.com/6504519/40561359-c1ef07f0-6011-11e8-879e-3f7e2fc8cd06.png">
