### PR TITLE
Don't render listings that have been hidden by address

### DIFF
--- a/src/actions/Listing.js
+++ b/src/actions/Listing.js
@@ -46,7 +46,8 @@ export function getListingIds() {
 
       dispatch({
         type: ListingConstants.FETCH_IDS_SUCCESS,
-        ids: showIds.reverse()
+        ids: showIds.reverse(),
+        hideList
       })
     } catch (error) {
       dispatch(showAlert(error.message))

--- a/src/components/listing-card.js
+++ b/src/components/listing-card.js
@@ -13,23 +13,30 @@ class ListingCard extends Component {
     super(props)
     this.state = {
       loading: true,
+      shouldRender: true
     }
   }
 
   async componentDidMount() {
     try {
       const listing = await origin.listings.getByIndex(this.props.listingId)
-      const obj = Object.assign({}, listing, { loading: false })
+      if (!this.props.hideList.includes(listing.address)) {
+        const obj = Object.assign({}, listing, { loading: false })
 
-      this.setState(obj)
+        this.setState(obj)
+      } else {
+        this.setState({ shouldRender: false })
+      }
     } catch (error) {
       console.error(`Error fetching contract or IPFS info for listingId: ${this.props.listingId}`)
     }
   }
 
   render() {
-    const { address, category, loading, name, pictures, price, unitsAvailable } = this.state
+    const { address, category, loading, name, pictures, price, unitsAvailable, shouldRender } = this.state
     const photo = pictures && pictures.length && (new URL(pictures[0])).protocol === "data:" && pictures[0]
+
+    if (!shouldRender) return false
 
     return (
       <div className={`col-12 col-md-6 col-lg-4 listing-card${loading ? ' loading' : ''}`}>

--- a/src/components/listings-grid.js
+++ b/src/components/listings-grid.js
@@ -22,7 +22,7 @@ class ListingsGrid extends Component {
 
   render() {
     const { listingsPerPage } = this.state
-    const { contractFound, listingIds } = this.props
+    const { contractFound, listingIds, hideList } = this.props
 
     const activePage = this.props.match.params.activePage || 1
     // Calc listings to show for given page
@@ -46,7 +46,7 @@ class ListingsGrid extends Component {
             {listingIds.length > 0 && <h1>{listingIds.length} Listings</h1>}
             <div className="row">
               {showListingsIds.map(listingId => (
-                <ListingCard listingId={listingId} key={listingId} />
+                <ListingCard listingId={listingId} key={listingId} hideList={hideList} />
               ))}
             </div>
             <Pagination
@@ -68,6 +68,7 @@ class ListingsGrid extends Component {
 
 const mapStateToProps = state => ({
   listingIds: state.listings.ids,
+  hideList: state.listings.hideList,
   contractFound: state.listings.contractFound
 })
 

--- a/src/reducers/Listings.js
+++ b/src/reducers/Listings.js
@@ -2,6 +2,7 @@ import { ListingConstants } from '../actions/Listing'
 
 const initialState = {
   ids: [],
+  hideList: [],
   contractFound: true
 }
 
@@ -12,7 +13,7 @@ export default function Listings(state = initialState, action = {}) {
         return { ...state, ids: [], contractFound: action.contractFound }
 
       case ListingConstants.FETCH_IDS_SUCCESS:
-        return { ...state, ids: action.ids }
+        return { ...state, ids: action.ids, hideList: action.hideList }
 
       default:
         return state


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double check you didn't break anything
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:
A possible solution for: https://github.com/OriginProtocol/demo-dapp/issues/221

Hides listings that have been flagged in the `hide_list` branch - by address instead of by index. We're transitioning away from indices to addresses.

The only awkwardness of this implementation is that on a page with flagged listings, the grid won't be completely filled up. For example:

<img width="1183" alt="screen shot 2018-05-25 at 4 38 28 pm" src="https://user-images.githubusercontent.com/6504519/40569861-1874dd02-603a-11e8-9f74-1c18870edb7c.png">

We can fix this eventually, it will just require updating the API to return listing addresses instead of indices when fetching all listings.


### Testing locally:

- Change [this line](https://github.com/OriginProtocol/demo-dapp/blob/develop/src/actions/Listing.js#L35) to be `if (true) {`.
- Change [this line](https://github.com/OriginProtocol/demo-dapp/blob/develop/src/actions/Listing.js#L37) to be `https://raw.githubusercontent.com/OriginProtocol/demo-dapp/tyleryasaka/hide_list_test/hidelist_${networkId}.json`