### PR TITLE
Issue/hidelist show index

### DIFF
--- a/src/actions/Listing.js
+++ b/src/actions/Listing.js
@@ -18,8 +18,6 @@ export function getListingIds() {
 
     let hideList = []
     const { web3, listingsRegistryContract } = origin.contractService
-    const inProductionEnv =
-      window.location.hostname === 'demo.originprotocol.com'
 
     try {
       let networkId = await web3.eth.net.getId()
@@ -32,7 +30,7 @@ export function getListingIds() {
         return
       }
 
-      if (inProductionEnv && networkId < 10) {
+      if (networkId < 10) { // Networks >9 are local test networks
         let response = await fetch(
           `https://raw.githubusercontent.com/OriginProtocol/demo-dapp/hide_list/hidelist_${networkId}.json`
         )

--- a/src/actions/Listing.js
+++ b/src/actions/Listing.js
@@ -44,8 +44,7 @@ export function getListingIds() {
 
       dispatch({
         type: ListingConstants.FETCH_IDS_SUCCESS,
-        ids: showIds.reverse(),
-        hideList
+        ids: showIds.reverse()
       })
     } catch (error) {
       dispatch(showAlert(error.message))

--- a/src/components/listing-card.js
+++ b/src/components/listing-card.js
@@ -50,7 +50,7 @@ class ListingCard extends Component {
             </div>
           }
           <div className="category placehold">{category}</div>
-          <h2 className="title placehold text-truncate">{name}</h2>
+          <h2 className="title placehold text-truncate" data-listing-index={this.props.listingId}>{name}</h2>
           {price > 0 && <ListingCardPrices price={price} unitsAvailable={unitsAvailable} />}
         </Link>
       </div>

--- a/src/components/listing-card.js
+++ b/src/components/listing-card.js
@@ -12,31 +12,23 @@ class ListingCard extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      loading: true,
-      shouldRender: true
+      loading: true
     }
   }
 
   async componentDidMount() {
     try {
       const listing = await origin.listings.getByIndex(this.props.listingId)
-      if (!this.props.hideList.includes(listing.address)) {
-        const obj = Object.assign({}, listing, { loading: false })
-
-        this.setState(obj)
-      } else {
-        this.setState({ shouldRender: false })
-      }
+      const obj = Object.assign({}, listing, { loading: false })
+      this.setState(obj)
     } catch (error) {
       console.error(`Error fetching contract or IPFS info for listingId: ${this.props.listingId}`)
     }
   }
 
   render() {
-    const { address, category, loading, name, pictures, price, unitsAvailable, shouldRender } = this.state
+    const { address, category, loading, name, pictures, price, unitsAvailable } = this.state
     const photo = pictures && pictures.length && (new URL(pictures[0])).protocol === "data:" && pictures[0]
-
-    if (!shouldRender) return false
 
     return (
       <div className={`col-12 col-md-6 col-lg-4 listing-card${loading ? ' loading' : ''}`}>

--- a/src/components/listings-grid.js
+++ b/src/components/listings-grid.js
@@ -22,7 +22,7 @@ class ListingsGrid extends Component {
 
   render() {
     const { listingsPerPage } = this.state
-    const { contractFound, listingIds, hideList } = this.props
+    const { contractFound, listingIds } = this.props
 
     const activePage = this.props.match.params.activePage || 1
     // Calc listings to show for given page
@@ -46,7 +46,7 @@ class ListingsGrid extends Component {
             {listingIds.length > 0 && <h1>{listingIds.length} Listings</h1>}
             <div className="row">
               {showListingsIds.map(listingId => (
-                <ListingCard listingId={listingId} key={listingId} hideList={hideList} />
+                <ListingCard listingId={listingId} key={listingId} />
               ))}
             </div>
             <Pagination
@@ -68,7 +68,6 @@ class ListingsGrid extends Component {
 
 const mapStateToProps = state => ({
   listingIds: state.listings.ids,
-  hideList: state.listings.hideList,
   contractFound: state.listings.contractFound
 })
 

--- a/src/reducers/Listings.js
+++ b/src/reducers/Listings.js
@@ -2,7 +2,6 @@ import { ListingConstants } from '../actions/Listing'
 
 const initialState = {
   ids: [],
-  hideList: [],
   contractFound: true
 }
 
@@ -13,7 +12,7 @@ export default function Listings(state = initialState, action = {}) {
         return { ...state, ids: [], contractFound: action.contractFound }
 
       case ListingConstants.FETCH_IDS_SUCCESS:
-        return { ...state, ids: action.ids, hideList: action.hideList }
+        return { ...state, ids: action.ids }
 
       default:
         return state


### PR DESCRIPTION
### Checklist:

- [X] Test your work and double check you didn't break anything

### Description:

Reveals a listing's index (`listingId`) in a data prop on grid card, so that moderators can add this id to hide_list. 

Removes @tyleryasaka 's temp fix for hiding based on addresses, as it would result in entire blank pages for The Great Kettle Bell Attack of 2018. We'll wait for a full conversion to address-based references to Listings, which he already has a PR for on origin-js

All Kettle Bell listings already added to hide_list branch. 

![new-troy-kettlebell](https://user-images.githubusercontent.com/673455/40627205-d3ea07aa-627a-11e8-95af-903939c3d731.jpg)
