### PR TITLE
Add component for displaying Etherscan links

### DIFF
--- a/src/components/etherscan-link.js
+++ b/src/components/etherscan-link.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react'
+
+class EtherscanLink extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {networkName: null}
+  }
+
+  async componentDidMount() {
+    const networkName = await web3.eth.net.getNetworkType() // Actually returns name, e.g. 'ropsten'
+    this.setState({networkName})
+  }
+
+  render() {
+
+    const { hash } = this.props
+    const { networkName } = this.state
+    let href, path
+
+    if (!hash) {
+      throw new Error("EtherscanLink: hash must exist")
+    }
+
+    // detect transaction hashes
+    if (hash.length === 66) {
+      path = `tx/${hash}`
+    // detect address hashes
+    } else if (hash.length === 42) {
+      path = `address/${hash}`
+    } else {
+      throw new Error("Unrecognized hash for EtherscanLink")
+    }
+
+    // link to the correct
+    if (networkName === "main") {
+      href = `https://etherscan.io/${path}`
+    } else if (networkName !== "private") {
+      href = `https://${networkName}.etherscan.io/${path}`
+    }
+
+    return <a target="_blank" href={href}>{hash}</a>
+  }
+}
+
+export default EtherscanLink

--- a/src/components/purchase-detail.js
+++ b/src/components/purchase-detail.js
@@ -382,12 +382,10 @@ class PurchaseDetail extends Component {
                 <div className="col-6">
                   <Link to={`/users/${seller.address}`}>
                     <div className="d-flex">
-                      <Link to={`/users/${seller.address}`}>
-                        <Avatar
-                          image={seller.profile && seller.profile.avatar}
-                          placeholderStyle={perspective === 'seller' ? 'green' : 'blue'}
-                        />
-                      </Link>
+                      <Avatar
+                        image={seller.profile && seller.profile.avatar}
+                        placeholderStyle={perspective === 'seller' ? 'green' : 'blue'}
+                      />
                       <div className="identification d-flex flex-column justify-content-between text-truncate">
                         <div><span className="badge badge-dark">Seller</span></div>
                         <div className="name">{sellerName}</div>
@@ -404,12 +402,10 @@ class PurchaseDetail extends Component {
                         <div className="name">{buyerName}</div>
                         <div className="address text-muted text-truncate">{buyer.address}</div>
                       </div>
-                      <Link to={`/users/${buyer.address}`}>
-                        <Avatar
-                          image={buyer.profile && buyer.profile.avatar}
-                          placeholderStyle={perspective === 'buyer' ? 'green' : 'blue'}
-                        />
-                      </Link>
+                      <Avatar
+                        image={buyer.profile && buyer.profile.avatar}
+                        placeholderStyle={perspective === 'buyer' ? 'green' : 'blue'}
+                      />
                     </div>
                   </Link>
                 </div>

--- a/src/components/purchase-detail.js
+++ b/src/components/purchase-detail.js
@@ -493,7 +493,7 @@ class PurchaseDetail extends Component {
               <hr />
             </div>
             <div className="col-12 col-lg-4">
-              <UserCard title={counterparty} userAddress={counterpartyUser.address} />
+              {counterpartyUser.address && <UserCard title={counterparty} userAddress={counterpartyUser.address} />}
             </div>
           </div>
           <div className="row">

--- a/src/components/purchase-detail.js
+++ b/src/components/purchase-detail.js
@@ -380,34 +380,38 @@ class PurchaseDetail extends Component {
               <h2>Transaction Status</h2>
               <div className="row">
                 <div className="col-6">
-                  <div className="d-flex">
-                    <Link to={`/users/${seller.address}`}>
-                      <Avatar
-                        image={seller.profile && seller.profile.avatar}
-                        placeholderStyle={perspective === 'seller' ? 'green' : 'blue'}
-                      />
-                    </Link>
-                    <div className="identification d-flex flex-column justify-content-between text-truncate">
-                      <div><span className="badge badge-dark">Seller</span></div>
-                      <div className="name"><Link to={`/users/${seller.address}`}>{sellerName}</Link></div>
-                      <div className="address text-muted text-truncate">{seller.address}</div>
+                  <Link to={`/users/${seller.address}`}>
+                    <div className="d-flex">
+                      <Link to={`/users/${seller.address}`}>
+                        <Avatar
+                          image={seller.profile && seller.profile.avatar}
+                          placeholderStyle={perspective === 'seller' ? 'green' : 'blue'}
+                        />
+                      </Link>
+                      <div className="identification d-flex flex-column justify-content-between text-truncate">
+                        <div><span className="badge badge-dark">Seller</span></div>
+                        <div className="name">{sellerName}</div>
+                        <div className="address text-muted text-truncate">{seller.address}</div>
+                      </div>
                     </div>
-                  </div>
+                  </Link>
                 </div>
                 <div className="col-6">
-                  <div className="d-flex justify-content-end">
-                    <div className="identification d-flex flex-column text-right justify-content-between text-truncate">
-                      <div><span className="badge badge-dark">Buyer</span></div>
-                      <div className="name"><Link to={`/users/${buyer.address}`}>{buyerName}</Link></div>
-                      <div className="address text-muted text-truncate">{buyer.address}</div>
+                  <Link to={`/users/${buyer.address}`}>
+                    <div className="d-flex justify-content-end">
+                      <div className="identification d-flex flex-column text-right justify-content-between text-truncate">
+                        <div><span className="badge badge-dark">Buyer</span></div>
+                        <div className="name">{buyerName}</div>
+                        <div className="address text-muted text-truncate">{buyer.address}</div>
+                      </div>
+                      <Link to={`/users/${buyer.address}`}>
+                        <Avatar
+                          image={buyer.profile && buyer.profile.avatar}
+                          placeholderStyle={perspective === 'buyer' ? 'green' : 'blue'}
+                        />
+                      </Link>
                     </div>
-                    <Link to={`/users/${buyer.address}`}>
-                      <Avatar
-                        image={buyer.profile && buyer.profile.avatar}
-                        placeholderStyle={perspective === 'buyer' ? 'green' : 'blue'}
-                      />
-                    </Link>
-                  </div>
+                  </Link>
                 </div>
                 <div className="col-12">
                   <TransactionProgress currentStep={step} maxStep={maxStep} purchase={listing} perspective={perspective} />
@@ -481,7 +485,7 @@ class PurchaseDetail extends Component {
                   }
 
                   {receivedAt &&
-                    <TransactionEvent tinmestamp={receivedAt} eventName="Received by buyer" transaction={receivedAt} buyer={buyer} seller={seller} />
+                    <TransactionEvent timestamp={receivedAt} eventName="Received by buyer" transaction={receivedAt} buyer={buyer} seller={seller} />
                   }
 
                   {withdrawnAt &&

--- a/src/components/user-card.js
+++ b/src/components/user-card.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { fetchUser } from 'actions/User'
 import Avatar from './avatar'
+import EtherscanLink from './etherscan-link'
 
 class UserCard extends Component {
   constructor(props) {
@@ -31,7 +32,7 @@ class UserCard extends Component {
             </div>
             <div>
               <div>ETH Address:</div>
-              <div className="address"><strong>{userAddress}</strong></div>
+              <div className="address">{userAddress && <EtherscanLink hash={userAddress} />}</div>
             </div>
           </div>
           <hr className="dark sm" />

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -208,7 +208,7 @@ a:hover {
 }
 
 .identification a {
-  color: white;
+  color: var(--dusk);
 }
 
 .user-card .identification > div {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -204,6 +204,7 @@ a:hover {
 }
 
 .identification .name {
+  color: var(--dark);
   font-weight: bold;
 }
 

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -209,7 +209,7 @@ a:hover {
 }
 
 .identification a {
-  color: var(--dusk);
+  color: white;
 }
 
 .user-card .identification > div {

--- a/src/pages/profile/_Wallet.js
+++ b/src/pages/profile/_Wallet.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 
 import Identicon from 'components/Identicon'
+import EtherscanLink from '../../components/etherscan-link'
 
 class Wallet extends Component {
   render() {
@@ -15,7 +16,7 @@ class Wallet extends Component {
           <div className="eth d-flex flex-column justify-content-between">
             {address && <div>ETH Address:</div>}
             <div className="address">
-              <strong>{address || 'No ETH Account Connected'}</strong>
+             {address ? <EtherscanLink hash={address} /> : 'No ETH Account Connected'}
             </div>
           </div>
         </div>

--- a/src/pages/purchases/transaction-event.js
+++ b/src/pages/purchases/transaction-event.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react'
+import EtherscanLink from '../../components/etherscan-link'
+import moment from 'moment'
+
+class TransactionEvent extends Component {
+
+  render() {
+
+    const { eventName, timestamp, transaction, buyer, seller } = this.props
+
+    const eventTitle = `${eventName} on <br /><strong>${moment(timestamp).format('MMM D, YYYY')}</strong>`
+  
+    return <tr>
+      <td><span className="progress-circle checked" data-toggle="tooltip" data-placement="top" data-html="true" title={eventTitle}></span>{eventName}</td>
+      <td className="text-truncate">{transaction && <EtherscanLink hash={transaction.transactionHash} />}</td>
+      <td className="text-truncate">{buyer.address && <EtherscanLink hash={buyer.address} />}</td>
+      <td className="text-truncate">{seller.address && <EtherscanLink hash={seller.address} />}</td>
+    </tr>
+    
+  }
+}
+
+export default TransactionEvent


### PR DESCRIPTION
Adds a universal component for displaying Etherscan links. You simply pass in a hash for an address or transaction and it will create an Etherscan link that points to the right network (rinkeby.etherscan.io, etc) and the right URL path (/address or /tx).