### PR TITLE
Crowdin integration - fix error in Crowdin console 

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
   - source: /translations/all-messages.json
-    translation: /translations/languages/%two_letters_code%/%original_file_name%
+    translation: /translations/languages/%language%/%original_file_name%


### PR DESCRIPTION
### Checklist:
- [x] Test your work and double check you didn't break anything

### Description:
Fixing the below error that appeared in the Crowdin console. This change will just affect the directory name where Crowdin will place the translated files when it creates PRs. The script that relies on this hasn't been written yet, so there is no change needed outside of this one file. 

<img width="692" alt="screenshot 2018-06-17 23 36 14" src="https://user-images.githubusercontent.com/5402813/41519805-7d50132c-7287-11e8-9785-21615274fef6.png">

